### PR TITLE
Dov/chore/catalog type

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,15 @@
       "name": "Launch Program",
       "program": "${workspaceFolder}/scratchpad/build/scratchpad/index.js",
       "outFiles": ["${workspaceFolder}/**/*.js"]
+    },
+    {
+      "name": "TS File",
+      "type": "node",
+      "request": "launch",
+      "args": ["${file}"],
+      "runtimeArgs": ["--nolazy", "-r", "ts-node/register"],
+      "sourceMaps": true,
+      "env": {}
     }
   ]
 }

--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -151,7 +151,10 @@ export default class PDFDocument {
       throwOnInvalidObject,
       capNumbers,
     ).parseDocument();
-    if (!!context.lookup(context.trailerInfo.Encrypt) && password!==undefined) {
+    if (
+      !!context.lookup(context.trailerInfo.Encrypt) &&
+      password !== undefined
+    ) {
       // Decrypt
       const fileIds = context.lookup(context.trailerInfo.ID, PDFArray);
       const encryptDict = context.lookup(context.trailerInfo.Encrypt, PDFDict);

--- a/src/core/crypto.ts
+++ b/src/core/crypto.ts
@@ -15,13 +15,13 @@
 
 import { arrayAsString, isArrayEqual } from '../utils/arrays';
 import { stringAsByteArray } from '../utils/strings';
-import PDFBool from './objects/PDFBool.js';
-import PDFDict from './objects/PDFDict.js';
-import PDFName from './objects/PDFName.js';
-import PDFNumber from './objects/PDFNumber.js';
-import PDFString from './objects/PDFString.js';
-import DecryptStream from './streams/DecryptStream.js';
-import { StreamType } from './streams/Stream.js';
+import PDFBool from './objects/PDFBool';
+import PDFDict from './objects/PDFDict';
+import PDFName from './objects/PDFName';
+import PDFNumber from './objects/PDFNumber';
+import PDFString from './objects/PDFString';
+import DecryptStream from './streams/DecryptStream';
+import { StreamType } from './streams/Stream';
 
 class ARCFourCipher {
   private s: Uint8Array;

--- a/src/core/parser/PDFObjectParser.ts
+++ b/src/core/parser/PDFObjectParser.ts
@@ -219,7 +219,7 @@ class PDFObjectParser extends BaseParser {
     this.bytes.assertNext(CharCodes.GreaterThan);
     this.bytes.assertNext(CharCodes.GreaterThan);
 
-    const Type = dict.get(PDFName.of('Type'));
+    const Type = dict.get(PDFName.of('Type')) ?? this.inferType(dict);
 
     if (Type === PDFName.of('Catalog')) {
       return PDFCatalog.fromMapWithContext(dict, this.context);
@@ -230,6 +230,19 @@ class PDFObjectParser extends BaseParser {
     } else {
       return PDFDict.fromMapWithContext(dict, this.context);
     }
+  }
+
+  // If we're here its because there was no Type key
+  // Infer the type based on the structure of the dict
+  private inferType(dict: DictMap): PDFName | undefined {
+    // Catalog is critical to successful parsing
+    // if there's pages, lets assume its a catalog
+    const Pages = dict.get(PDFName.of('Pages'));
+    if (Pages !== undefined) {
+      return PDFName.of('Catalog');
+    }
+
+    return undefined;
   }
 
   protected parseDictOrStream(ref?: PDFRef): PDFDict | PDFStream {

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -75,7 +75,7 @@ export const getType = (val: any) => {
   if (val === null) return 'null';
   if (val === undefined) return 'undefined';
   if (typeof val === 'string') return 'string';
-  if (isNaN(val)) return 'NaN';
+  if (Number.isNaN(val)) return 'NaN';
   if (typeof val === 'number') return 'number';
   if (typeof val === 'boolean') return 'boolean';
   if (typeof val === 'symbol') return 'symbol';


### PR DESCRIPTION
Turns out some catalogs are not labeled catalog. If there's no type, we'll try to infer a type. 

### Good 
<img width="670" alt="image" src="https://github.com/user-attachments/assets/cade5e46-d841-49e8-a736-cc11d1341d0a" />

### No Catalog
<img width="856" alt="image" src="https://github.com/user-attachments/assets/8a54c215-b295-414f-80aa-c604230741aa" />

### Note
`Type` and `Pages` are the two required properties for catalog, but we'd rather be supportive 
<img width="797" alt="image" src="https://github.com/user-attachments/assets/c7191725-ad8a-4219-a208-a06251f89c61" />

<img width="780" alt="image" src="https://github.com/user-attachments/assets/5565d4ad-927f-44a0-881f-2aced623afd5" />
 
