### PR TITLE
Load encrypted ( but not password protected) PDF's

### DIFF
--- a/scratchpad/page.ts
+++ b/scratchpad/page.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+import { PDFDocument } from '../src/index';
+
+const inputPath = path.join(
+  __dirname,
+  '..',
+  'assets',
+  'pdfs',
+  'american_flag.pdf',
+);
+
+const outputPath = path.join(
+  __dirname,
+  '..',
+  'assets',
+  'pdfs',
+  'american_flag_page_0.pdf',
+);
+
+(async () => {
+  const src = fs.readFileSync(inputPath);
+  const srcDoc = await PDFDocument.load(src);
+  const dstDoc = await PDFDocument.create();
+
+  const [extractedPage] = await dstDoc.copyPages(srcDoc, [0]);
+  dstDoc.addPage(extractedPage);
+
+  const dst = await dstDoc.save();
+
+  fs.writeFileSync(outputPath, dst);
+})();


### PR DESCRIPTION
Support encrypted PDF's that do not need passwords. 

The heavy lifting had already been done, this just allows the use case to pass. 

Unfortunately I don't have a sample document I can share, but here's some excerpts  from one

<img width="730" alt="image" src="https://github.com/user-attachments/assets/772e61d4-f6d3-4330-905c-814bbdb21c7b" />

<img width="1052" alt="image" src="https://github.com/user-attachments/assets/dcc8850f-cced-40a0-8802-43219bdc77e2" />


